### PR TITLE
Remove obsolete architecture links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,4 @@ Provide a modular platform where new functional templates can plug in quickly wh
 
 ## Four-Layer Agent Architecture
 
-![Four-layer agent diagram](docs/architecture/four-layer-diagram.png)
-
-Further design details can be found in the [architecture documentation](docs/architecture/README.md).
+The platform is organized into a four-layer hierarchy of agents. Detailed design documentation will be added in a future release.


### PR DESCRIPTION
## Summary
- delete broken links to `docs/architecture` from README

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `python -m detect_secrets scan --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678acf0a4c83308af8ed34423c2f52