### PR TITLE
Update sanity test to cover config

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,2 +1,29 @@
-def test_sanity():
-    assert True
+def test_sanity(monkeypatch):
+    required = [
+        "OPENAI_API_KEY",
+        "AZURE_CLIENT_ID",
+        "AZURE_TENANT_ID",
+        "AZURE_SUBSCRIPTION_ID",
+        "POSTGRES_USER",
+        "POSTGRES_PASSWORD",
+        "POSTGRES_DB",
+    ]
+
+    for var in required:
+        monkeypatch.setenv(var, "dummy")
+
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+
+    import importlib
+
+    config = importlib.import_module("virtual_department.config")
+    importlib.reload(config)
+
+    expected = {var: "dummy" for var in required}
+
+    assert config.CONFIG == expected


### PR DESCRIPTION
## Summary
- expand the sanity test to exercise `virtual_department.config`
- patch required environment variables and reload the module

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68679352fa7c83308dd96d736d182e81