### PR TITLE
Fix coverage badge job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
-          path: coverage.xml
+          path: |
+            coverage.xml
+            .coverage
 
   infra-plan:
     needs: lint-and-test
@@ -88,7 +90,7 @@ jobs:
           path: .
       - uses: tj-actions/coverage-badge-py@v2
         with:
-          coverage_regex: "TOTAL.*\\s+(\\d+%)"
+          overwrite: true
       - uses: EndBug/add-and-commit@v9
         with:
           add: "*.svg"


### PR DESCRIPTION
## Summary
- upload both coverage.xml and `.coverage`
- adjust coverage badge action to use default settings

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867959d711c8330aceea106c544ebd8