### PR TITLE
Fix coverage badge job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
-          path: coverage.xml
+          path: |
+            coverage.xml
+            .coverage
 
   infra-plan:
     needs: lint-and-test
@@ -85,10 +87,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: coverage-xml
-          path: .
+          path: coverage
+      - name: Prepare coverage files
+        run: mv coverage/* .
       - uses: tj-actions/coverage-badge-py@v2
         with:
-          coverage_regex: "TOTAL.*\\s+(\\d+%)"
+          overwrite: true
       - uses: EndBug/add-and-commit@v9
         with:
           add: "*.svg"


### PR DESCRIPTION
## Summary
- ensure downloaded coverage files are placed at repo root so `coverage-badge` can find them

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867959d711c8330aceea106c544ebd8