### PR TITLE
Run infra plan on pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
   infra-plan:
     needs: lint-and-test
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -105,6 +105,7 @@ jobs:
         run: terraform -chdir=infrastructure show -no-color plan.out > plan.txt
 
       - name: Comment plan
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
- run the CI infra-plan job on push events
- restrict the plan-comment step to pull requests

## Testing
- `ruff check .`
- `black --check .`
- `isort --check-only .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a87827448330b6dddc29308b7dd2